### PR TITLE
included Credentials.cs in project

### DIFF
--- a/MindBodyStar/MindBodyStar.csproj
+++ b/MindBodyStar/MindBodyStar.csproj
@@ -161,6 +161,7 @@
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
       <DependentUpon>Settings.settings</DependentUpon>
     </Compile>
+    <Compile Include="Services\Credentials.cs" />
     <Compile Include="Services\StarRewardService.cs" />
     <Compile Include="Web References\AppointmentService\Reference.cs">
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
When I pulled this down, it initially wouldn't build because the Credentials.cs file wasn't include in the csproj.